### PR TITLE
Implemented additional check for stubbing

### DIFF
--- a/Fetch/Code/Network/APIClient.swift
+++ b/Fetch/Code/Network/APIClient.swift
@@ -189,7 +189,7 @@ public class APIClient {
     }
     
     private func register<T>(_ resource: Resource<T>) {
-        guard let stub = resource.stub else { return }
+        guard let stub = resource.stubIfNeeded else { return }
         
         StubbedURL.registerStub(stub, for: stub.id.uuidString)
     }


### PR DESCRIPTION
Adds an additional check for stubbing in the APIClient. This change only avoids that requests are registered as stubs when stubbing is set to false.