### PR TITLE
Fix stubs when using multiple APIClients

### DIFF
--- a/Sources/Fetch/Network/APIClient.swift
+++ b/Sources/Fetch/Network/APIClient.swift
@@ -130,7 +130,6 @@ open class APIClient {
     
     public func setStubProvider(_ stubProvider: StubProvider) {
         _config?.stubProvider = stubProvider
-        StubbedURL.stubProvider = _config?.stubProvider
     }
     
     /// Configures an `APIClient` with the given `config`
@@ -144,8 +143,6 @@ open class APIClient {
         let configuration = config.urlSession
         configuration.protocolClasses = config.protocolClasses + [StubbedURL.self]
         configuration.timeoutIntervalForRequest = config.timeout
-        
-        StubbedURL.stubProvider = config.stubProvider
         
         session = Session(
             configuration: configuration,
@@ -168,6 +165,8 @@ open class APIClient {
     
     @discardableResult internal func request<T>(_ resource: Resource<T>, queue: DispatchQueue, completion: @escaping CompletionCallback<T>) -> RequestToken {
         precondition(_config != nil, "Setup of APIClient was not called!")
+        
+        StubbedURL.stubProvider = config.stubProvider
         
         var urlRequest: URLRequest
         do {

--- a/Sources/Fetch/Network/APIClient.swift
+++ b/Sources/Fetch/Network/APIClient.swift
@@ -166,15 +166,13 @@ open class APIClient {
     @discardableResult internal func request<T>(_ resource: Resource<T>, queue: DispatchQueue, completion: @escaping CompletionCallback<T>) -> RequestToken {
         precondition(_config != nil, "Setup of APIClient was not called!")
         
-        StubbedURL.stubProvider = config.stubProvider
-        
         var urlRequest: URLRequest
         do {
             urlRequest = try resource.asURLRequest()
             
             // register stub if needed
             if config.shouldStub ?? false && stubProvider.stub(for: resource) != nil {
-                StubbedURL.stubProvider = _config?.stubProvider
+                StubbedURL.stubProvider = config.stubProvider
                 urlRequest.headers.add(name: StubbedURL.stubIdHeader, value: resource.stubKey)
             }
             

--- a/Sources/Fetch/Network/APIClient.swift
+++ b/Sources/Fetch/Network/APIClient.swift
@@ -174,6 +174,7 @@ open class APIClient {
             
             // register stub if needed
             if config.shouldStub ?? false && stubProvider.stub(for: resource) != nil {
+                StubbedURL.stubProvider = _config?.stubProvider
                 urlRequest.headers.add(name: StubbedURL.stubIdHeader, value: resource.stubKey)
             }
             


### PR DESCRIPTION
The stubProvider in StubbedURL got overwritten when a new APIClient was created and so if there where any stubs registered the will be gone when running the request so the preconditionFailure("Stubbed request was not set correctly") was thrown

So no the stubProvider for the StubbedURL is always set before the request is fired - so the correct StubProvider is in charge - not the prettiest fix for now, but for now easier to implement than to rethink the stubbing.